### PR TITLE
1.8.1-1

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -312,7 +312,6 @@ func (a *API) middlewareOrigin(ctx *gin.Context) {
 
 func (a *API) middlewareAuth(ctx *gin.Context) {
 	user, pass, hasCredentials := ctx.Request.BasicAuth()
-
 	err := a.AuthManager.Authenticate(&auth.Request{
 		User:   user,
 		Pass:   pass,

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -153,7 +153,6 @@ func (m *Manager) authenticateInner(req *Request) error {
 			}
 		}
 	}
-
 	switch m.Method {
 	case conf.AuthMethodInternal:
 		return m.authenticateInternal(req, &rtspAuthHeader)

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -126,8 +126,8 @@ type Conf struct {
 	LogLevel            LogLevel        `json:"logLevel"`
 	LogDestinations     LogDestinations `json:"logDestinations"`
 	LogFile             string          `json:"logFile"`
-  LogStreams                bool            `json:"logStreams"`
-	LogDirStreams             string          `json:"logDirStreams"`
+	LogStreams          bool            `json:"logStreams"`
+	LogDirStreams       string          `json:"logDirStreams"`
 	ReadTimeout         StringDuration  `json:"readTimeout"`
 	WriteTimeout        StringDuration  `json:"writeTimeout"`
 	ReadBufferCount     *int            `json:"readBufferCount,omitempty"` // deprecated
@@ -249,9 +249,10 @@ type Conf struct {
 	SRTAddress string `json:"srtAddress"`
 
 	// Record (deprecated)
-	Record                *bool           `json:"record,omitempty"`                // deprecated
-	RecordAudio           *bool           `json:"recordAudio,omitempty"`           // deprecated
-	RecordPath            *string         `json:"recordPath,omitempty"`            // deprecated
+	Record                *bool           `json:"record,omitempty"`      // deprecated
+	RecordAudio           *bool           `json:"recordAudio,omitempty"` // deprecated
+	RecordPath            *string         `json:"recordPath,omitempty"`        
+	RecordPaths           *[]string         `json:"recordPaths,omitempty"`              
 	RecordFormat          *RecordFormat   `json:"recordFormat,omitempty"`          // deprecated
 	RecordPartDuration    *StringDuration `json:"recordPartDuration,omitempty"`    // deprecated
 	RecordSegmentDuration *StringDuration `json:"recordSegmentDuration,omitempty"` // deprecated
@@ -654,7 +655,6 @@ func (conf *Conf) Validate() error {
 			return fmt.Errorf("at least one between 'webrtcIPsFromInterfaces' or 'webrtcAdditionalHosts' must be filled")
 		}
 	}
-
 	// Record (deprecated)
 	if conf.Record != nil {
 		conf.PathDefaults.Record = *conf.Record
@@ -664,6 +664,9 @@ func (conf *Conf) Validate() error {
 	}
 	if conf.RecordPath != nil {
 		conf.PathDefaults.RecordPath = *conf.RecordPath
+	}
+	if conf.RecordPaths != nil {
+		conf.PathDefaults.RecordPaths = *conf.RecordPaths
 	}
 	if conf.RecordFormat != nil {
 		conf.PathDefaults.RecordFormat = *conf.RecordFormat

--- a/internal/conf/database.go
+++ b/internal/conf/database.go
@@ -15,6 +15,7 @@ type Database struct {
 	UseUpdaterStatus     bool   `json:"useUpdaterStatus"`
 	UseSrise             bool   `json:"useSrise"`
 	UseProxy             bool   `json:"useProxy"`
+	FileSQLErr           string `json:"fileSQLErr"`
 	Sql                  Sql    `json:"sql"`
 }
 
@@ -45,6 +46,7 @@ func (db *Database) setDefaults() {
 	db.UseUpdaterStatus = false
 	db.UseSrise = false
 	db.UseProxy = false
+	db.FileSQLErr = "./"
 	db.Sql = Sql{
 		InsertPath:    "",
 		GetPathStream: "",

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -102,6 +102,7 @@ type Path struct {
 	RecordAudio           bool           `json:"recordAudio"`
 	Playback              bool           `json:"playback"`
 	RecordPath            string         `json:"recordPath"`
+	RecordPaths           []string        `json:"recordPaths"`   
 	RecordFormat          RecordFormat   `json:"recordFormat"`
 	RecordPartDuration    StringDuration `json:"recordPartDuration"`
 	RecordSegmentDuration StringDuration `json:"recordSegmentDuration"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -40,6 +40,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/servers/webrtc"
 	"github.com/bluenviron/mediamtx/internal/storage"
 	"github.com/bluenviron/mediamtx/internal/storage/psql"
+	"github.com/bluenviron/mediamtx/internal/errorSQL"
 )
 
 type MaxPub struct {
@@ -123,6 +124,8 @@ type Core struct {
 
 	// out
 	done chan struct{}
+
+	filesqlerror *errorsql.Filesqlerror
 }
 
 // New allocates a Core.
@@ -165,7 +168,6 @@ func New(args []string) (*Core, bool) {
 		fmt.Printf("ERR: %s\n", err)
 		return nil, false
 	}
-
 	err = p.createResources(true)
 	if err != nil {
 		if p.logger != nil {
@@ -277,7 +279,7 @@ func (p *Core) createResources(initial bool) error {
 			return err
 		}
 	}
-
+	p.filesqlerror = errorsql.CreateFilesqlerror()
 	if initial {
 		p.Log(logger.Info, "MediaMTX %s", version)
 
@@ -386,7 +388,7 @@ func (p *Core) createResources(initial bool) error {
 			return err
 		}
 		p.playbackServer = i
-		
+
 	}
 	if p.conf.Database.Use {
 		p.dbPool, err = database.CreateDbPool(
@@ -397,9 +399,8 @@ func (p *Core) createResources(initial bool) error {
 		)
 		if err != nil {
 			return err
-		}	
+		}
 	}
-	
 
 	if p.pathManager == nil {
 		req := psql.NewReq(p.ctx, p.dbPool)
@@ -413,6 +414,7 @@ func (p *Core) createResources(initial bool) error {
 			UseUpdaterStatus:     p.conf.Database.UseUpdaterStatus,
 			UseSrise:             p.conf.Database.UseSrise,
 			UseProxy:             p.conf.Database.UseProxy,
+			FileSQLErr:           p.conf.Database.FileSQLErr,
 			Sql:                  p.conf.Database.Sql,
 		}
 		if stor.UseProxy {
@@ -588,6 +590,7 @@ func (p *Core) createResources(initial bool) error {
 			logFile:           p.conf.LogFile,
 			logStreams:        p.conf.LogStreams,
 			logDirStreams:     p.conf.LogDirStreams,
+			authManager:       p.authManager,
 			rtspAddress:       p.conf.RTSPAddress,
 			readTimeout:       p.conf.ReadTimeout,
 			writeTimeout:      p.conf.WriteTimeout,
@@ -599,6 +602,7 @@ func (p *Core) createResources(initial bool) error {
 			stor:              stor,
 			Publisher:         MaxPub{Max: len(p.conf.Paths) - 1},
 			max:               p.conf.PathDefaults.MaxPublishers,
+			filesqlerror:      p.filesqlerror,
 		}
 		p.pathManager.initialize()
 
@@ -1247,6 +1251,9 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 
 	if closeDB && p.dbPool != nil {
 		database.ClosePool(p.dbPool)
+	}
+	if p.filesqlerror.File!=nil{
+		p.filesqlerror.CloseFile()
 	}
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -47,7 +47,7 @@ type MaxPub struct {
 	Max int
 }
 
-var version = "v1.5.1-8"
+var version = "v1.8.1-1"
 
 var defaultConfPaths = []string{
 	"rtsp-simple-server.yml",

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/stream"
 
 	"github.com/bluenviron/mediamtx/internal/storage"
+	"github.com/bluenviron/mediamtx/internal/errorSQL"
 )
 
 func pathConfCanBeUpdated(oldPathConf *conf.Path, newPathConf *conf.Path) bool {
@@ -92,6 +93,8 @@ type pathManager struct {
 	stor      storage.Storage
 	Publisher MaxPub
 	max       int
+
+	filesqlerror *errorsql.Filesqlerror
 }
 
 func (pm *pathManager) initialize() {
@@ -309,7 +312,6 @@ func (pm *pathManager) doDescribe(req defs.PathDescribeReq) {
 		req.Res <- defs.PathDescribeRes{Err: err}
 		return
 	}
-
 	err = pm.authManager.Authenticate(req.AccessRequest.ToAuthRequest())
 	if err != nil {
 		req.Res <- defs.PathDescribeRes{Err: err}
@@ -330,7 +332,6 @@ func (pm *pathManager) doAddReader(req defs.PathAddReaderReq) {
 		req.Res <- defs.PathAddReaderRes{Err: err}
 		return
 	}
-
 	if !req.AccessRequest.SkipAuth {
 		err = pm.authManager.Authenticate(req.AccessRequest.ToAuthRequest())
 		if err != nil {
@@ -423,6 +424,7 @@ func (pm *pathManager) createPath(
 		}
 		pa.loggerPath = logg
 	}
+	pa.filesqlerror = pm.filesqlerror
 	pa.initialize(pm.stor, &pm.Publisher)
 
 	pm.paths[name] = pa

--- a/internal/errorSQL/model.go
+++ b/internal/errorSQL/model.go
@@ -1,0 +1,21 @@
+package errorsql
+
+import (
+	"os"
+	"time"
+)
+
+type Filesqlerror struct {
+	File *os.File
+	Data string
+}
+
+func CreateFilesqlerror() *Filesqlerror {
+	return &Filesqlerror{
+		Data: time.Now().Format("2006-01-02"),
+	}
+}
+
+func (f *Filesqlerror) CloseFile() error {
+	return f.File.Close()
+}

--- a/internal/errorSQL/saving_request.go
+++ b/internal/errorSQL/saving_request.go
@@ -1,0 +1,37 @@
+package errorsql
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func (f *Filesqlerror) SavingRequest(filename string, message []byte) error {
+	data := time.Now().Format("2006-01-02")
+	if f.File == nil {
+		f.Data = data
+		f.File.Close()
+		filename = fmt.Sprintf("%s_%s.txt", strings.Split(filename, ".txt")[0], data)
+		file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		f.File = file
+	}
+	if data != f.Data {
+		f.Data = data
+		f.File.Close()
+		filename = fmt.Sprintf("%s_%s.txt", strings.Split(filename, ".txt")[0], data)
+		file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		f.File = file
+	}
+	_, err := f.File.Write(message)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/logger/logerStream.go
+++ b/internal/logger/logerStream.go
@@ -8,15 +8,6 @@ import (
 
 func NewLoggerStream(level Level, destinations []Destination, filePath string, nameStream string, logdir string) (*Logger, error) {
 	var errf error
-	if logdir == "" {
-		filePath = fmt.Sprintf("%s_%s.log", strings.Split(filePath, ".log")[0], nameStream)
-	} else {
-		if _, err := os.Stat(logdir); os.IsNotExist(err) {
-			errf = fmt.Errorf("the %s directory does not exist", logdir)
-			filePath = fmt.Sprintf("%s_%s.log", strings.Split(filePath, ".log")[0], nameStream)
-		} else {filePath = fmt.Sprintf("%s/%s_%s.log", logdir, strings.Split(strings.Split(filePath, ".log")[0], "/")[len(strings.Split(filePath, "/"))-1], nameStream)}
-		
-	}
 	lh := &Logger{
 		level: level,
 	}
@@ -27,6 +18,17 @@ func NewLoggerStream(level Level, destinations []Destination, filePath string, n
 			lh.destinations = append(lh.destinations, newDestionationStdout())
 
 		case DestinationFile:
+			if logdir == "" {
+				filePath = fmt.Sprintf("%s_%s.log", strings.Split(filePath, ".log")[0], nameStream)
+			} else {
+				if _, err := os.Stat(logdir); os.IsNotExist(err) {
+					errf = fmt.Errorf("the %s directory does not exist", logdir)
+					filePath = fmt.Sprintf("%s_%s.log", strings.Split(filePath, ".log")[0], nameStream)
+				} else {
+					filePath = fmt.Sprintf("%s/%s_%s.log", logdir, strings.Split(strings.Split(filePath, ".log")[0], "/")[len(strings.Split(filePath, "/"))-1], nameStream)
+				}
+
+			}
 			dest, err := newDestinationFile(filePath)
 			if err != nil {
 				lh.Close()

--- a/internal/record/agent.go
+++ b/internal/record/agent.go
@@ -7,12 +7,14 @@ import (
 	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/storage"
 	"github.com/bluenviron/mediamtx/internal/stream"
+	"github.com/bluenviron/mediamtx/internal/errorSQL"
 )
 
 // Agent writes recordings to disk.
 type Agent struct {
 	WriteQueueSize    int
 	PathFormat        string
+	PathFormats       []string
 	Format            conf.RecordFormat
 	PartDuration      time.Duration
 	SegmentDuration   time.Duration
@@ -32,6 +34,11 @@ type Agent struct {
 
 	Stor        storage.Storage
 	RecordAudio bool
+
+	PathStream string
+	CodeMp     string
+
+	Filesqlerror *errorsql.Filesqlerror
 }
 
 // Initialize initializes Agent.

--- a/internal/record/agent_instance.go
+++ b/internal/record/agent_instance.go
@@ -34,14 +34,11 @@ type agentInstance struct {
 	stor        storage.Storage
 	recordAudio bool
 	free        string
-	pathStream  string
-	codeMp      string
 	endTime     string
 	timeStart   string
 }
 
 func (a *agentInstance) initialize() {
-	a.agent.StreamName = a.agent.PathName
 	a.pathFormat = a.agent.PathFormat
 
 	a.pathFormat = PathAddExtension(
@@ -54,10 +51,7 @@ func (a *agentInstance) initialize() {
 
 	a.writer = asyncwriter.New(a.agent.WriteQueueSize, a.agent)
 
-	paths := strings.Split(a.agent.PathName, "/")
-	if len(paths) > 1 {
-		a.agent.StreamName = paths[len(paths)-1]
-	}
+
 
 	switch a.agent.Format {
 	case conf.RecordFormatMPEGTS:

--- a/internal/record/format_mpegts_segment.go
+++ b/internal/record/format_mpegts_segment.go
@@ -44,41 +44,36 @@ func (s *formatMPEGTSSegment) close() error {
 
 				if err3 == nil {
 					paths := strings.Split(s.path, "/")
-					s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(
+					query := fmt.Sprintf(
 						s.f.a.stor.Sql.UpdateSize,
 						fmt.Sprint(stat.Size()),
 						s.f.a.endTime,
 						paths[len(paths)-1],
-					)))
+					)
+					s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s", query))
 
-					err4 := s.f.a.stor.Req.ExecQuery(
-						fmt.Sprintf(
-							s.f.a.stor.Sql.UpdateSize,
-							fmt.Sprint(stat.Size()),
-							s.f.a.endTime,
-							paths[len(paths)-1],
-						))
-					s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
+					err4 := s.f.a.stor.Req.ExecQuery(query)
+
 					if err4 != nil {
 						if err4.Error() == "context canceled" {
-							s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(
-								s.f.a.stor.Sql.UpdateSize,
-								fmt.Sprint(stat.Size()),
-								s.f.a.endTime,
-								paths[len(paths)-1],
-							)))
-							
-							err4 = s.f.a.stor.Req.ExecQueryNoCtx(
-								fmt.Sprintf(
-									s.f.a.stor.Sql.UpdateSize,
-									fmt.Sprint(stat.Size()),
-									s.f.a.endTime,
-									paths[len(paths)-1],
-								))
+							s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s", query))
+
+							err4 = s.f.a.stor.Req.ExecQueryNoCtx(query)
+							if err4 != nil {
+								s.f.a.agent.Log(logger.Error, "%v", err4)
+								message := []byte(query + "\n")
+								s.f.a.agent.Filesqlerror.SavingRequest(s.f.a.stor.FileSQLErr, message)
+								return err4
+							}
 							s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
+							return err
 						}
-						return err4
+						s.f.a.agent.Log(logger.Error, "%v", err4)
+						message := []byte(query + "\n")
+						s.f.a.agent.Filesqlerror.SavingRequest(s.f.a.stor.FileSQLErr, message)
+						return err
 					}
+					s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
 					return err
 				}
 				err = err3
@@ -91,61 +86,31 @@ func (s *formatMPEGTSSegment) close() error {
 
 func (s *formatMPEGTSSegment) Write(p []byte) (int, error) {
 	if s.fi == nil {
-
 		var err error
-
 		if s.f.a.stor.DbDrives {
-			s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",s.f.a.stor.Sql.GetDrives))
-			data, err := s.f.a.stor.Req.SelectData(s.f.a.stor.Sql.GetDrives)
-			s.f.a.agent.Log(logger.Debug, "The result of executing the sql query: %v", data)
+			// проверка на использование бд, если бд не используеться будет записываться по локальным путям
+			if s.f.a.stor.Use {
+				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s", s.f.a.stor.Sql.GetDrives))
+				data, err := s.f.a.stor.Req.SelectData(s.f.a.stor.Sql.GetDrives)
+				if err != nil {
+					//записываем ошибку в лог и пробуем создать путь по локальному пути
+					s.f.a.agent.Log(logger.Error, "%v", err)
+					s.localCreatePath()
+				} else {
+					s.f.a.agent.Log(logger.Debug, "The result of executing the sql query: %v", data)
+					drives := []interface{}{}
+					for _, line := range data {
+						drives = append(drives, line[0].(string))
+					}
+					s.f.a.free = getMostFreeDisk(drives)
+					s.dbCreatingPaths()
+				}
 
-			if err != nil {
-				return 0, err
-			}
-			drives := []interface{}{}
-			for _, line := range data {
-				drives = append(drives, line[0].(string))
-			}
-			s.f.a.free = getMostFreeDisk(drives)
-			if s.f.a.stor.DbUseCodeMP_Contract && s.f.a.stor.UseDbPathStream {
-				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(s.f.a.stor.Sql.GetCodeMP, s.f.a.agent.StreamName)))
-				s.f.a.codeMp, err = s.f.a.stor.Req.SelectPathStream(fmt.Sprintf(s.f.a.stor.Sql.GetCodeMP, s.f.a.agent.StreamName))
-				if err != nil {
-					return 0, err
-				}
-				s.f.a.agent.Log(logger.Debug, "The result of executing the sql query: %s", s.f.a.codeMp)
-				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(s.f.a.stor.Sql.GetPathStream, s.f.a.agent.StreamName)))
-				s.f.a.pathStream, err = s.f.a.stor.Req.SelectPathStream(fmt.Sprintf(s.f.a.stor.Sql.GetPathStream, s.f.a.agent.StreamName))
-				if err != nil {
-					return 0, err
-				}
-				s.f.a.agent.Log(logger.Debug, "The result of executing the sql query: %s", s.f.a.pathFormat)
-				s.path = fmt.Sprintf(s.f.a.free+Path{Start: s.startNTP}.Encode(s.f.a.pathFormat), s.f.a.codeMp, s.f.a.pathStream)
-			}
-
-			if s.f.a.stor.DbUseCodeMP_Contract {
-				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(s.f.a.stor.Sql.GetCodeMP, s.f.a.agent.StreamName)))
-				s.f.a.codeMp, err = s.f.a.stor.Req.SelectPathStream(fmt.Sprintf(s.f.a.stor.Sql.GetCodeMP, s.f.a.agent.StreamName))
-				if err != nil {
-					return 0, err
-				}
-				s.f.a.agent.Log(logger.Debug, "The result of executing the sql query: %s", s.f.a.codeMp)
-				s.path = fmt.Sprintf(s.f.a.free+Path{Start: s.startNTP}.Encode(s.f.a.pathFormat), s.f.a.codeMp)
-			}
-			if s.f.a.stor.UseDbPathStream {
-				s.f.a.agent.Log(logger.Debug,fmt.Sprintf("SQL query sent:%s", fmt.Sprintf(s.f.a.stor.Sql.GetPathStream, s.f.a.agent.StreamName)))
-				s.f.a.pathStream, err = s.f.a.stor.Req.SelectPathStream(fmt.Sprintf(s.f.a.stor.Sql.GetPathStream, s.f.a.agent.StreamName))
-				if err != nil {
-					return 0, err
-				}
-				s.f.a.agent.Log(logger.Debug, "The result of executing the sql query: %s", s.f.a.pathStream)
-				s.path = fmt.Sprintf(s.f.a.free+Path{Start: s.startNTP}.Encode(s.f.a.pathFormat), s.f.a.pathStream)
-			}
-			if !s.f.a.stor.DbUseCodeMP_Contract && !s.f.a.stor.UseDbPathStream {
-				s.path = fmt.Sprintf(s.f.a.free + Path{Start: s.startNTP}.Encode(s.f.a.pathFormat))
+			} else {
+				s.localCreatePath()
 			}
 		} else {
-			s.path = Path{Start: s.startNTP}.Encode(s.f.a.pathFormat)
+			s.localCreatePath()
 		}
 
 		s.f.a.agent.Log(logger.Debug, "creating segment %s", s.path)
@@ -166,54 +131,44 @@ func (s *formatMPEGTSSegment) Write(p []byte) (int, error) {
 			paths := strings.Split(s.path, "/")
 			pathRec := strings.Join(paths[:len(paths)-1], "/")
 			if s.f.a.stor.UseDbPathStream {
-				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(
+				query := fmt.Sprintf(
 					s.f.a.stor.Sql.InsertPath,
 					pathRec+"/",
 					paths[len(paths)-1],
 					s.f.a.timeStart,
-					s.f.a.pathStream,
-					s.f.a.free,
-				)))
-
-				err := s.f.a.stor.Req.ExecQuery(
-					fmt.Sprintf(
-						s.f.a.stor.Sql.InsertPath,
-						pathRec+"/",
-						paths[len(paths)-1],
-						s.f.a.timeStart,
-						s.f.a.pathStream,
-						s.f.a.free,
-					),
+					s.f.a.agent.PathStream,
+				s.f.a.free,
 				)
+				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s", query))
+
+				err := s.f.a.stor.Req.ExecQuery(query)
+
 				if err != nil {
-					os.Remove(s.path)
-					return 0, err
+					s.f.a.agent.Log(logger.Error, "%v", err)
+					message := []byte(query + "\n")
+					s.f.a.agent.Filesqlerror.SavingRequest(s.f.a.stor.FileSQLErr, message)
+				} else {
+					s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
 				}
-				s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
+
 			} else {
-				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s",fmt.Sprintf(
+				query := fmt.Sprintf(
 					s.f.a.stor.Sql.InsertPath,
 					pathRec+"/",
 					paths[len(paths)-1],
 					s.f.a.timeStart,
 					s.f.a.agent.PathName,
 					s.f.a.free,
-				)))
-				err := s.f.a.stor.Req.ExecQuery(
-					fmt.Sprintf(
-						s.f.a.stor.Sql.InsertPath,
-						pathRec+"/",
-						paths[len(paths)-1],
-						s.f.a.timeStart,
-						s.f.a.agent.PathName,
-						s.f.a.free,
-					),
 				)
+				s.f.a.agent.Log(logger.Debug, fmt.Sprintf("SQL query sent:%s", query))
+				err := s.f.a.stor.Req.ExecQuery(query)
 				if err != nil {
-					os.Remove(s.path)
-					return 0, err
+					s.f.a.agent.Log(logger.Error, "%v", err)
+					message := []byte(query + "\n")
+					s.f.a.agent.Filesqlerror.SavingRequest(s.f.a.stor.FileSQLErr, message)
+				} else {
+					s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
 				}
-				s.f.a.agent.Log(logger.Debug, "The request was successfully completed")
 			}
 
 		}
@@ -224,4 +179,36 @@ func (s *formatMPEGTSSegment) Write(p []byte) (int, error) {
 	}
 
 	return s.fi.Write(p)
+}
+
+func (s *formatMPEGTSSegment) dbCreatingPaths() {
+	if s.f.a.stor.DbUseCodeMP_Contract && s.f.a.stor.UseDbPathStream {
+		s.path = fmt.Sprintf(s.f.a.free+Path{Start: s.startNTP}.Encode(s.f.a.pathFormat), s.f.a.agent.CodeMp, s.f.a.agent.PathStream)
+	} else {
+
+		if s.f.a.stor.DbUseCodeMP_Contract {
+
+			s.path = fmt.Sprintf(s.f.a.free+Path{Start: s.startNTP}.Encode(s.f.a.pathFormat), s.f.a.agent.CodeMp)
+		}
+		if s.f.a.stor.UseDbPathStream {
+			s.path = fmt.Sprintf(s.f.a.free+Path{Start: s.startNTP}.Encode(s.f.a.pathFormat), s.f.a.agent.PathStream)
+		}
+		if !s.f.a.stor.DbUseCodeMP_Contract && !s.f.a.stor.UseDbPathStream {
+			s.path = fmt.Sprintf(s.f.a.free + Path{Start: s.startNTP}.Encode(s.f.a.pathFormat))
+		}
+	}
+}
+
+func (s *formatMPEGTSSegment) localCreatePath() {
+	if len(s.f.a.agent.PathFormats) == 0 {
+		s.path = Path{Start: s.startNTP}.Encode(s.f.a.pathFormat)
+	} else {
+		if s.f.a.stor.Use {
+			s.f.a.free = getMostFreeDiskGroup(s.f.a.agent.PathFormats)
+			s.dbCreatingPaths()
+		} else {
+			s.f.a.free = getMostFreeDiskGroup(s.f.a.agent.PathFormats)
+			s.path = fmt.Sprintf(s.f.a.free + Path{Start: s.startNTP}.Encode(s.f.a.pathFormat))
+		}
+	}
 }

--- a/internal/record/methods_record_disk.go
+++ b/internal/record/methods_record_disk.go
@@ -1,6 +1,8 @@
 package record
 
-import "syscall"
+import (
+	"syscall"
+)
 
 type DiskStatus struct {
 	// всего места на диске
@@ -67,4 +69,35 @@ func getMostFreeDisk(drives []interface{}) (mostFree string) {
 	}
 
 	return mostFree
+}
+
+func getMostFreeDiskGroup(drives []string) (mostFree string) {
+
+	var min float64
+	infoDisks := allDiskUsagesGroup(drives)
+
+	for _, min = range infoDisks {
+		break
+	}
+
+	for disk, free := range infoDisks {
+		if free > min {
+			continue
+		}
+
+		mostFree, min = disk, free
+	}
+
+	return mostFree
+}
+
+func allDiskUsagesGroup(drives []string) map[string]float64 {
+
+	infoDisks := make(map[string]float64)
+
+	for _, path := range drives {
+		disk := diskUsage(path)
+		infoDisks[path] = (float64(disk.All) - float64(disk.Avail)) / float64(disk.All)
+	}
+	return infoDisks
 }

--- a/internal/storage/model.go
+++ b/internal/storage/model.go
@@ -15,5 +15,6 @@ type Storage struct {
 	UseUpdaterStatus     bool
 	UseSrise             bool
 	UseProxy             bool
+	FileSQLErr           string
 	Sql                  conf.Sql
 }

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -12,7 +12,9 @@ logLevel: debug
 logDestinations: [file]
 # If "file" is in logDestinations, this is the file which will receive the logs.
 logFile: mediamtx.log
+# Enabling the creation of separate log files by streams
 logStreams: yes
+# The path for creating log files by streams is specified, if the path is empty, log files will be created along the path of the main log file
 logDirStreams: /home/major/go/src/github.com/major1ink/bluenviron/mediamtx/streams/
 # Timeout of read operations.
 readTimeout: 10s
@@ -456,7 +458,7 @@ pathDefaults:
   # Available variables are %path (path name), %Y %m %d %H %M %S %f %s (time in strftime format)
   #/ttttt/%v/%Y-%m-%d/%path-%s-%f
   recordPath: /%v/%Y-%m-%d/%path-%s-%f
-  
+  # if the db Drive s field is "no", then local paths for saving video files are specified.
   recordPaths: 
     - /media/anton/Tom2/video
     - /media/anton/Tom/video
@@ -735,8 +737,9 @@ database:
   useSrise: no
   # Enable/disable the server start with proxy streams from the database.
   useProxy: no
-  # SQL queryes 
+  # Specifies the path and file name to save the file with outstanding sql queries
   fileSQLErr: ./SQL_ERROR.txt
+    # SQL queryes 
   sql:
     # SQL query to insert video record
     # EXAMPLE insertPath: "INSERT INTO \"video_record\" (\"stream\", \"path_record\", \"file_name\", \"date_time_start\") VALUES ('%s', '%s', '%s', '%s')" 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -9,7 +9,7 @@
 # Verbosity of the program; available values are "error", "warn", "info", "debug".
 logLevel: debug
 # Destinations of log messages; available values are "stdout", "file" and "syslog".
-logDestinations: [stdout]
+logDestinations: [file]
 # If "file" is in logDestinations, this is the file which will receive the logs.
 logFile: mediamtx.log
 logStreams: yes
@@ -455,7 +455,12 @@ pathDefaults:
   # Extension is added automatically.
   # Available variables are %path (path name), %Y %m %d %H %M %S %f %s (time in strftime format)
   #/ttttt/%v/%Y-%m-%d/%path-%s-%f
-  recordPath: ./%Y-%m-%d/%path-%s-%f
+  recordPath: /%v/%Y-%m-%d/%path-%s-%f
+  
+  recordPaths: 
+    - /media/anton/Tom2/video
+    - /media/anton/Tom/video
+    - /home/anton/go/video
   # Format of recorded segments.
   # Available formats are "fmp4" (fragmented MP4) and "mpegts" (MPEG-TS).
   recordFormat: mpegts
@@ -717,13 +722,13 @@ database:
   # Maximum number of connections
   maxConnections: 1
   # Enable/disable discs from the database for recording
-  dbDrives: no
+  dbDrives: yes
   # Enable/disable the code_mp_contract field to create a record path
   dbUseCodeMP_Contract: no
   # Enable/disable the contract field to create a straem path. Work with useSrise: yes
   dbUseContract: no
   #
-  useDbPathStream: no
+  useDbPathStream: yes
   # Enable/disable updating the status of a stream in the database
   useUpdaterStatus: no
   # Enable/disable the server start with streams from the database
@@ -731,11 +736,12 @@ database:
   # Enable/disable the server start with proxy streams from the database.
   useProxy: no
   # SQL queryes 
+  fileSQLErr: ./SQL_ERROR.txt
   sql:
     # SQL query to insert video record
     # EXAMPLE insertPath: "INSERT INTO \"video_record\" (\"stream\", \"path_record\", \"file_name\", \"date_time_start\") VALUES ('%s', '%s', '%s', '%s')" 
     # L3
-    insertPath: "INSERT INTO \"VideoRecord\" (\"pathRecord\", \"fileName\",\"recordTime\", \"stream\", \"id_storage\") VALUES ('%s', '%s','%s','%s', '4')"
+    insertPath: "INSERT INTO \"VideoRecord\" (\"pathRecord\", \"fileName\",\"recordTime\", \"stream\", \"id_storage\") VALUES ('%s', '%s','%s','%s', '4'22222222)"
     # L6
     # insertPath: "INSERT INTO \"video_record\" (\"path_record\", \"file_name\",\"date_time_start\", \"code_mp_cam\", \"id_storage\") VALUES ('%s', '%s','%s','%s', (SELECT \"id_storage\" FROM \"public\".\"storage_disks\" WHERE \"mount_point\" ='%s'))"
     #
@@ -749,7 +755,7 @@ database:
     # L6
     # updateSize: "UPDATE \"video_record\" SET \"file_size\"='%s', \"date_time_end\"='%s' WHERE \"file_name\"='%s'"
     # request to get a list of discs to burn
-    getDrives: "SELECT sd.\"mount_point\" FROM \"storage_disks\" sd JOIN \"storage_servers\" ss ON ss.\"id\"=sd.\"id_storage\" WHERE ss.\"state\"='3' AND sd.\"state\"='0' AND sd.\"status\"='0' ORDER BY sd.\"mount_point\""
+    getDrives: "SELECT sd.\"mount_point\" FROM \"storage_disks\" sd JOIN \"storage_servers\" ss ON ss.\"id\"=sd.\"id_storage\" WHERE ss.\"state\"='3' AND sd.\"state\"='0' AND sd.\"status\"='0' ORDER BY sd.\"mount_point\"111111111111111111111111111111111111111"
     # request to update stream statuses
     # L3
     updateStatus: "UPDATE public.\"VideoPublic\" SET \"StatusPublic\"='%d' WHERE \"Stream\"='%s'"
@@ -761,4 +767,5 @@ database:
     getDataContract: "SELECT vc.\"id\", (CASE WHEN vc.\"login\" ISNULL THEN '' ELSE vc.\"login\" END), (CASE WHEN vc.\"pass\" ISNULL THEN '' ELSE vc.\"pass\" END), vc.\"ip_address_out\", (CASE WHEN vc.\"cam_path\" ISNULL THEN '' ELSE vc.\"cam_path\" END), vc.\"code_mp\", (CASE WHEN vc.\"state_public\" ISNULL THEN '0' ELSE vc.\"state_public\" END),(CASE WHEN vc.\"status_public\" ISNULL THEN '0' ELSE vc.\"status_public\" END), mpc.\"code_mp_contract\", vcont.\"record_status\" FROM \"public\".\"videocameras\" vc JOIN \"public\".\"mount_place_cam\" mpc ON vc.\"code_mp\"=mpc.\"code_mp_cam\" JOIN \"video_contract\" vcont ON mpc.\"code_mp_contract\" = vcont.\"code_mp\" WHERE vc.\"cam_path\" NOTNULL AND vc.\"state_public\" = '1'"
     # for l3
     getDataForProxy: "SELECT vp.\"Stream\", vs.\"srv_address_dvc\" FROM \"VideoPublic\" vp JOIN \"DataDevice\" dd ON vp.\"Stream\" = dd.\"UID\" JOIN \"MountPlace\" mp ON dd.\"codeMP\" = mp.\"codeMP\" JOIN \"video_servers\" vs ON mp.\"id_video_servers\" = vs.\"id\" WHERE vp.\"StatePublic\" = '1' LIMIT 20"    
+
 


### PR DESCRIPTION
Было реализовано сохранение по путям указанных в конфигурационном фале. Был изменен принцип работы с БД:
1) Были перемены запросы на получение данных о стримам на уровень ниже
2) При получении ошибки на запрос по получению путей для сохранения пути будет браться локально.
3) При получении ошибки на занесение сведений о видео файле в БД файл не будет удалятся и будет формироваться txt файл с не выполнены sql запросом
Добавлено поле   
1)  # if the db Drive s field is "no", then local paths for saving video files are specified.
  recordPaths: 
    - /media/anton/Tom2/video
указывается после recordPath
2)   # Specifies the path and file name to save the file with outstanding sql queries
  fileSQLErr: ./SQL_ERROR.txt
указывается после useProxy